### PR TITLE
Support maximization quadratization

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -61,6 +61,7 @@ PBO.relaxedgcd
 ## Quadratization
 
 ```@docs
+PBO.Quadratization
 PBO.quadratize
 PBO.quadratize!
 PBO.infer_quadratization

--- a/docs/src/manual/4-quadratization.md
+++ b/docs/src/manual/4-quadratization.md
@@ -1,7 +1,17 @@
 # Quadratization
 
-A Quadratization is a mapping ``\mathcal{Q}\{f\}: \mathsrc{F} \to \mathsrc{F}^{2}`` such that
+A Quadratization is a mapping ``\mathcal{Q}\{f\}: \mathscr{F} \to \mathscr{F}^{2}`` that preserves the optimization over auxiliary variables.
+
+For minimization, the default `sign = 1` gives
 
 ```math
-\min_{\mathbf{y}} \mathsrc{Q}\{f\}(\mathbf{x}, \mathbf{y}) = f(\mathbf{x}) ~\forall \mathbf{x} \in \mathbb{B}^{n}.~\forall f \in \mathsrc{F}.
+\min_{\mathbf{y}} \mathcal{Q}\{f\}(\mathbf{x}, \mathbf{y}) = f(\mathbf{x}) ~\forall \mathbf{x} \in \mathbb{B}^{n}.~\forall f \in \mathscr{F}.
 ```
+
+For maximization, use `sign = -1` so that
+
+```math
+\max_{\mathbf{y}} \mathcal{Q}\{f\}(\mathbf{x}, \mathbf{y}) = f(\mathbf{x}) ~\forall \mathbf{x} \in \mathbb{B}^{n}.~\forall f \in \mathscr{F}.
+```
+
+The `sign` keyword controls the objective sense used to select and validate term reductions. The quadratized function keeps coefficients in the original objective scale.

--- a/src/interface/quadratization.jl
+++ b/src/interface/quadratization.jl
@@ -1,17 +1,38 @@
 #  :: Quadratization ::  #
 abstract type QuadratizationMethod end
 
+@doc raw"""
+    Quadratization(method::QuadratizationMethod; stable::Bool = false, sign::Integer = 1)
+
+Configures a quadratization method.
+
+The `sign` keyword controls the objective sense used to choose and validate term
+reductions. Use `sign = 1` for minimization and `sign = -1` for maximization.
+"""
 struct Quadratization{Q<:QuadratizationMethod}
     method::Q
     stable::Bool
+    sign::Int
 
-    function Quadratization{Q}(method::Q, stable::Bool = false) where {Q<:QuadratizationMethod}
-        return new{Q}(method, stable)
+    function Quadratization{Q}(
+        method::Q,
+        stable::Bool = false,
+        sign::Integer = 1,
+    ) where {Q<:QuadratizationMethod}
+        if !(sign in (-1, 1))
+            throw(ArgumentError("Quadratization sign must be either -1 or 1"))
+        end
+
+        return new{Q}(method, stable, Int(sign))
     end
 end
 
-function Quadratization(method::Q; stable::Bool = false) where {Q<:QuadratizationMethod}
-    return Quadratization{Q}(method, stable)
+function Quadratization(
+    method::Q;
+    stable::Bool = false,
+    sign::Integer = 1,
+) where {Q<:QuadratizationMethod}
+    return Quadratization{Q}(method, stable, sign)
 end
 
 @doc raw"""

--- a/src/interface/quadratization.jl
+++ b/src/interface/quadratization.jl
@@ -8,6 +8,8 @@ Configures a quadratization method.
 
 The `sign` keyword controls the objective sense used to choose and validate term
 reductions. Use `sign = 1` for minimization and `sign = -1` for maximization.
+Coefficients in the quadratized function remain in the original objective
+scale.
 """
 struct Quadratization{Q<:QuadratizationMethod}
     method::Q
@@ -46,6 +48,20 @@ function infer_quadratization end
     quadratize(aux, f::PBF{V, T}, ::Quadratization{Q}) where {V,T,Q}
 
 Quadratizes a given PBF, i.e., applies a mapping ``\mathcal{Q} : \mathscr{F}^{k} \to \mathscr{F}^{2}``, where ``\mathcal{Q}`` is the quadratization method.
+
+For `Quadratization(...; sign = 1)`, the returned function preserves
+minimization over auxiliary variables:
+
+```math
+\min_{\mathbf{y}} \mathcal{Q}\{f\}(\mathbf{x}, \mathbf{y}) = f(\mathbf{x}).
+```
+
+For `Quadratization(...; sign = -1)`, it preserves maximization over auxiliary
+variables:
+
+```math
+\max_{\mathbf{y}} \mathcal{Q}\{f\}(\mathbf{x}, \mathbf{y}) = f(\mathbf{x}).
+```
 
 ## Auxiliary variables
 The `aux` function is expected to produce auxiliary variables with the following signatures:

--- a/src/library/quadratization/default.jl
+++ b/src/library/quadratization/default.jl
@@ -1,5 +1,5 @@
 @doc raw"""
-    Quadratization(::DEFAULT; stable::Bool = false)
+    Quadratization(::DEFAULT; stable::Bool = false, sign::Integer = 1)
 
 Employs [`NTR_KZFD`](@ref) for negative terms and [`PTR_BG`](@ref) for the positive ones.
 """
@@ -14,10 +14,22 @@ function quadratize!(
 ) where {V,T}
     length(ω) < 3 && return f # Fast-track
 
-    if c < zero(T)
-        quadratize!(aux, f, ω, c, Quadratization(NTR_KZFD(); stable=quad.stable))
+    if quad.sign * c < zero(T)
+        quadratize!(
+            aux,
+            f,
+            ω,
+            c,
+            Quadratization(NTR_KZFD(); stable=quad.stable, sign=quad.sign),
+        )
     else
-        quadratize!(aux, f, ω, c, Quadratization(PTR_BG(); stable=quad.stable))
+        quadratize!(
+            aux,
+            f,
+            ω,
+            c,
+            Quadratization(PTR_BG(); stable=quad.stable, sign=quad.sign),
+        )
     end
 
     return f

--- a/src/library/quadratization/ntr_kzfd.jl
+++ b/src/library/quadratization/ntr_kzfd.jl
@@ -1,5 +1,5 @@
 @doc raw"""
-    Quadratization(::NTR_KZFD; stable::Bool = false)
+    Quadratization(::NTR_KZFD; stable::Bool = false, sign::Integer = 1)
 
 ## Negative term reduction NTR-KZFD[^NTR_KZFD]
 
@@ -33,9 +33,9 @@ function quadratize!(
     f::F,
     ω::AbstractTerm{V},
     c::T,
-    ::Quadratization{NTR_KZFD},
+    quad::Quadratization{NTR_KZFD},
 ) where {V,T,F<:AbstractPBF{V,T}}
-    @assert c < zero(T)
+    @assert quad.sign * c < zero(T)
 
     # Degree
     k = length(ω)

--- a/src/library/quadratization/ptr_bg.jl
+++ b/src/library/quadratization/ptr_bg.jl
@@ -29,8 +29,10 @@ function quadratize!(
     f::F,
     ω::AbstractTerm{V},
     c::T,
-    ::Quadratization{PTR_BG},
+    quad::Quadratization{PTR_BG},
 ) where {V,T,F<:AbstractPBF{V,T}}
+    @assert quad.sign * c > zero(T)
+
     # Degree
     k = length(ω)
 

--- a/src/library/quadratization/ptr_bg.jl
+++ b/src/library/quadratization/ptr_bg.jl
@@ -1,5 +1,5 @@
 @doc raw"""
-    Quadratization(::PTR_BG; stable::Bool = false)
+    Quadratization(::PTR_BG; stable::Bool = false, sign::Integer = 1)
 
 ## Positive term reduction PTR-BG[^PTR_BG]
 

--- a/test/assets/assets.jl
+++ b/test/assets/assets.jl
@@ -70,12 +70,16 @@ function run_foreign_pkg_tests(pkg_name::AbstractString, dep_path::AbstractStrin
 
         Pkg.develop(; path = dep_path)
 
-        Pkg.add(pkg_name)
+        # Some foreign test suites, such as QUBOTools' Documenter tests, expect
+        # package sources to live in a Git checkout with remotes.
+        Pkg.develop(pkg_name)
 
         Pkg.status()
         
         @test try
-            Pkg.test(pkg_name; kws...)
+            withenv("JULIA_PKG_PRECOMPILE_AUTO" => "0") do
+                Pkg.test(pkg_name; kws...)
+            end
 
             true
         catch e

--- a/test/unit/quadratization.jl
+++ b/test/unit/quadratization.jl
@@ -120,6 +120,8 @@ end
 
 function test_DEFAULT()
     @testset "→ DEFAULT" begin
+        @test_throws ArgumentError PBO.Quadratization(PBO.DEFAULT(); sign = 0)
+
         @testset "∴ TermDict/Integer" begin
             let V = Int, T = Float64, F = PBO.TermDictPBF{V,T}
                 let f = F(
@@ -183,6 +185,53 @@ function test_DEFAULT()
                     q = PBO.quadratize(f, PBO.Quadratization(PBO.DEFAULT(); stable = true))
 
                     @test q == g
+                end
+            end
+        end
+
+        @testset "∴ TermDict/Symbol/Maximization" begin
+            let V = Symbol, T = Float64, F = PBO.TermDictPBF{V,T}
+                let f = F([:x, :y, :z] => 1.0)
+                    q = PBO.quadratize(
+                        f,
+                        PBO.Quadratization(PBO.DEFAULT(); stable = true, sign = -1),
+                    )
+
+                    @test q == F([
+                        :aux_1       => -2.0,
+                        (:x, :aux_1) => 1.0,
+                        (:y, :aux_1) => 1.0,
+                        (:z, :aux_1) => 1.0,
+                    ])
+
+                    for x in 0:1, y in 0:1, z in 0:1
+                        ξ = Dict(:x => x, :y => y, :z => z)
+                        @test maximum(
+                            convert(T, q(merge(ξ, Dict(:aux_1 => s)))) for s in 0:1
+                        ) == convert(T, f(ξ))
+                    end
+                end
+
+                let f = F([:x, :y, :z] => -1.0)
+                    q = PBO.quadratize(
+                        f,
+                        PBO.Quadratization(PBO.DEFAULT(); stable = true, sign = -1),
+                    )
+
+                    @test q == F([
+                        :aux_1       => -1.0,
+                        (:x, :aux_1) => -1.0,
+                        (:y, :aux_1) => 1.0,
+                        (:z, :aux_1) => 1.0,
+                        (:y, :z)     => -1.0,
+                    ])
+
+                    for x in 0:1, y in 0:1, z in 0:1
+                        ξ = Dict(:x => x, :y => y, :z => z)
+                        @test maximum(
+                            convert(T, q(merge(ξ, Dict(:aux_1 => s)))) for s in 0:1
+                        ) == convert(T, f(ξ))
+                    end
                 end
             end
         end

--- a/test/unit/quadratization.jl
+++ b/test/unit/quadratization.jl
@@ -25,6 +25,25 @@ function test_NTR_KZFD()
                         (:w, :aux_1) => -2.0,
                     ])
                 end
+
+                let f = F([:x, :y, :z] => 1.0)
+                    q = PBO.quadratize(
+                        f,
+                        PBO.Quadratization(PBO.NTR_KZFD(); stable = true, sign = -1),
+                    )
+
+                    @test q == F([
+                        :aux_1       => -2.0,
+                        (:x, :aux_1) => 1.0,
+                        (:y, :aux_1) => 1.0,
+                        (:z, :aux_1) => 1.0,
+                    ])
+                end
+
+                @test_throws AssertionError PBO.quadratize(
+                    F([:x, :y, :z] => -1.0),
+                    PBO.Quadratization(PBO.NTR_KZFD(); stable = true, sign = -1),
+                )
             end
         end
     end
@@ -64,6 +83,26 @@ function test_PTR_BG()
                         (:y, :z) => 2.0,
                     ])
                 end
+
+                let f = F([:x, :y, :z] => -1.0)
+                    q = PBO.quadratize(
+                        f,
+                        PBO.Quadratization(PBO.PTR_BG(); stable = true, sign = -1),
+                    )
+
+                    @test q == F([
+                        :aux_1       => -1.0,
+                        (:x, :aux_1) => -1.0,
+                        (:y, :aux_1) => 1.0,
+                        (:z, :aux_1) => 1.0,
+                        (:y, :z)     => -1.0,
+                    ])
+                end
+
+                @test_throws AssertionError PBO.quadratize(
+                    F([:x, :y, :z] => 1.0),
+                    PBO.Quadratization(PBO.PTR_BG(); stable = true, sign = -1),
+                )
             end
 
             @testset "∴ TermDict/Integer" begin


### PR DESCRIPTION
## Summary

- Add a validated `sign` keyword to `Quadratization` for minimization (`sign = 1`) and maximization (`sign = -1`) quadratization.
- Use the effective signed coefficient for `DEFAULT` method selection and `NTR_KZFD` applicability checks while preserving the returned function in the original coefficient scale.
- Document the public `Quadratization` constructor and add maximization tests for flipped default method selection.

## Tests run

- `julia --project=. -e 'using Test, PseudoBooleanOptimization; const PBO = PseudoBooleanOptimization; include("test/unit/quadratization.jl"); test_quadratization()'`
  - Passed: `⊛ Quadratization | 25 25`
- `julia --project=. -e 'import Pkg; Pkg.test()'`
  - Passed: `PseudoBooleanOptimization tests passed`, 154/154 tests.
- `julia --project=docs --compiled-modules=no docs/make.jl --skip-deploy`
  - Passed with existing warnings for `PseudoBooleanOptimization.image` and `PseudoBooleanOptimization.variables` docstrings not included in the manual; deployment skipped intentionally.

## Notes

- The docs workflow setup command `julia --project=docs -e 'using Pkg; Pkg.develop(path=pwd()); Pkg.instantiate()'` was attempted locally, but Julia 1.11.5 hung during Kroki precompilation on a background TCP handle. I stopped that hung process and ran the docs build with compiled modules disabled.

Closes #6
