### PR TITLE
Fix docs preview cleanup for missing previews

### DIFF
--- a/.github/workflows/docscleanup.yml
+++ b/.github/workflows/docscleanup.yml
@@ -9,21 +9,29 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout gh-pages branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: gh-pages
 
       - name: Delete preview and history
+        id: cleanup
         run: |
             git config user.name "Documenter.jl"
             git config user.email "documenter@juliadocs.github.io"
-            git rm -rf "previews/PR$PRNUM"
+            git rm -rf --ignore-unmatch "previews/PR$PRNUM"
+            if git diff --cached --quiet; then
+                echo "No preview found for PR$PRNUM"
+                echo "changed=false" >> "$GITHUB_OUTPUT"
+                exit 0
+            fi
             git commit -m "delete preview"
             git branch gh-pages-new $(echo "delete history" | git commit-tree HEAD^{tree})
+            echo "changed=true" >> "$GITHUB_OUTPUT"
         env:
             PRNUM: ${{ github.event.number }}
 
       - name: Push changes
+        if: steps.cleanup.outputs.changed == 'true'
         run: |
             git push --force origin gh-pages-new:gh-pages
             


### PR DESCRIPTION
Summary:
- Make the documentation preview cleanup workflow tolerate already-missing preview directories.
- Skip the force-push step when there is no preview deletion to commit.
- Update the touched workflow from `actions/checkout@v2` to `actions/checkout@v4`.

Tests run:
- `actionlint .github/workflows/docscleanup.yml` - passed.
- `git diff --check` - passed.
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/docscleanup.yml"); puts "YAML parse passed"'` - passed.
- Throwaway git-repository simulation of the cleanup script:
  - missing `previews/PR8` writes `changed=false` and creates no `gh-pages-new` branch;
  - existing `previews/PR8` deletes the preview, writes `changed=true`, and creates `gh-pages-new`;
  - result: passed.

Notes about tests not run:
- Julia package tests were not run because this PR only changes a GitHub Actions cleanup workflow and does not touch package source, docs source, or tests.

Fixes failed workflow run: https://github.com/JuliaQUBO/PseudoBooleanOptimization.jl/actions/runs/26226695798
