### PR TITLE
Clean legacy links and author metadata

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PseudoBooleanOptimization"
 uuid = "c8fa9a04-bc42-452d-8558-dc51757be744"
-authors = ["pedromxavier <pedrox@cos.ufrj.br>"]
+authors = ["pedromxavier <pedrox@cos.ufrj.br>", "David E. Bernal Neira <dbernaln@purdue.edu>"]
 version = "0.2.5"
 
 [deps]

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
     </a>
     <br>
 
-[![codecov](https://codecov.io/gh/psrenergy/PseudoBooleanOptimization.jl/graph/badge.svg?token=87V5MR99ET)](https://codecov.io/gh/psrenergy/PseudoBooleanOptimization.jl)
-[![CI](https://github.com/psrenergy/PseudoBooleanOptimization.jl/actions/workflows/ci.yml/badge.svg?branch=main)](/actions/workflows/ci.yml)
-[![Docs](https://img.shields.io/badge/docs-dev-blue.svg)](https://psrenergy.github.io/PseudoBooleanOptimization.jl/dev)
+[![codecov](https://codecov.io/gh/JuliaQUBO/PseudoBooleanOptimization.jl/graph/badge.svg?token=87V5MR99ET)](https://codecov.io/gh/JuliaQUBO/PseudoBooleanOptimization.jl)
+[![CI](https://github.com/JuliaQUBO/PseudoBooleanOptimization.jl/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/JuliaQUBO/PseudoBooleanOptimization.jl/actions/workflows/ci.yml)
+[![Docs](https://img.shields.io/badge/docs-dev-blue.svg)](https://JuliaQUBO.github.io/PseudoBooleanOptimization.jl/dev)
 
 </div>
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -40,7 +40,7 @@ if "--skip-deploy" ∈ ARGS
     @warn "Skipping deployment"
 else
     deploydocs(
-        repo = raw"github.com/psrenergy/PseudoBooleanOptimization.jl.git",
+        repo = raw"github.com/JuliaQUBO/PseudoBooleanOptimization.jl.git",
         push_preview = true,
     )
 end

--- a/test/unit/ci.jl
+++ b/test/unit/ci.jl
@@ -17,5 +17,21 @@ function test_ci_configuration()
         @test occursin("version: '$(compat_floor.match)'", docs_config)
     end
 
+    @testset "Repository metadata" begin
+        repo_root = normpath(joinpath(@__DIR__, "..", ".."))
+        project   = TOML.parsefile(joinpath(repo_root, "Project.toml"))
+        readme    = read(joinpath(repo_root, "README.md"), String)
+        docs_make = read(joinpath(repo_root, "docs", "make.jl"), String)
+        legacy_owner = "psr" * "energy"
+
+        @test !occursin(legacy_owner, readme)
+        @test !occursin(legacy_owner, docs_make)
+        @test occursin("https://codecov.io/gh/JuliaQUBO/PseudoBooleanOptimization.jl", readme)
+        @test occursin("https://github.com/JuliaQUBO/PseudoBooleanOptimization.jl/actions/workflows/ci.yml", readme)
+        @test occursin("https://JuliaQUBO.github.io/PseudoBooleanOptimization.jl/dev", readme)
+        @test occursin(raw"github.com/JuliaQUBO/PseudoBooleanOptimization.jl.git", docs_make)
+        @test "David E. Bernal Neira <dbernaln@purdue.edu>" in project["authors"]
+    end
+
     return nothing
 end


### PR DESCRIPTION
## Summary

- Updated README badges and documentation links to use `JuliaQUBO/PseudoBooleanOptimization.jl`.
- Updated the Documenter deployment repository to `github.com/JuliaQUBO/PseudoBooleanOptimization.jl.git`.
- Added `David E. Bernal Neira <dbernaln@purdue.edu>` to `Project.toml` authors.
- Added a regression test for repository metadata links and author metadata.

## Tests run

- `julia --project=. -e 'using Test, TOML; include("test/unit/ci.jl"); test_ci_configuration()'` - passed, 11 tests.
- `julia --project=. -e 'using Pkg; Pkg.test()'` - passed, 169 tests.
- `git diff --check` - passed.

## Notes

- `julia --project=docs -e 'using Pkg; Pkg.develop(path=pwd()); Pkg.instantiate()'` was attempted for docs CI setup, but local precompilation hung in `Kroki` while waiting on background IO and was stopped; no tracked files changed.

Closes #12
