### PR TITLE
Add Dependabot dependency maintenance

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+  - package-ecosystem: "julia"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      root-julia-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "julia"
+    directory: "/docs"
+    schedule:
+      interval: "weekly"
+    groups:
+      docs-julia-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/test/unit/ci.jl
+++ b/test/unit/ci.jl
@@ -4,9 +4,10 @@ function test_ci_configuration()
     @testset "CI configuration" begin
         repo_root = normpath(joinpath(@__DIR__, "..", ".."))
         workflows = joinpath(repo_root, ".github", "workflows")
-        project     = TOML.parsefile(joinpath(repo_root, "Project.toml"))
-        ci_config   = read(joinpath(workflows, "ci.yml"), String)
-        docs_config = read(joinpath(workflows, "docs.yml"), String)
+        project           = TOML.parsefile(joinpath(repo_root, "Project.toml"))
+        ci_config         = read(joinpath(workflows, "ci.yml"), String)
+        docs_config       = read(joinpath(workflows, "docs.yml"), String)
+        dependabot_config = read(joinpath(repo_root, ".github", "dependabot.yml"), String)
 
         julia_compat = project["compat"]["julia"]
         compat_floor = match(r"\d+(?:\.\d+){0,2}", julia_compat)
@@ -15,6 +16,14 @@ function test_ci_configuration()
         @test occursin("version: '$(compat_floor.match)'", ci_config)
         @test occursin("version: '1'", ci_config)
         @test occursin("version: '$(compat_floor.match)'", docs_config)
+        dependabot_julia_updates = collect(eachmatch(r"package-ecosystem: \"julia\"", dependabot_config))
+
+        @test length(dependabot_julia_updates) == 2
+        @test occursin("root-julia-dependencies", dependabot_config)
+        @test occursin("docs-julia-dependencies", dependabot_config)
+        @test occursin("directory: \"/docs\"", dependabot_config)
+        @test occursin("package-ecosystem: \"github-actions\"", dependabot_config)
+        @test occursin("interval: \"monthly\"", dependabot_config)
     end
 
     @testset "Repository metadata" begin


### PR DESCRIPTION
## Summary

- Add `.github/dependabot.yml` using the finalized JuliaQUBO dependency-maintenance policy.
- Enable weekly Julia updates for the root package and `docs/`, where separate `[compat]` bounds are maintained.
- Enable monthly GitHub Actions updates.
- Add repository-configuration tests that assert the Dependabot entries remain present.

## Secrets and permissions

Dependabot does not require a repository secret or PAT for this public Julia package repository using the public General registry. No CompatHelper workflow is added. A dedicated PAT is only relevant for custom or private registry workflows that still require CompatHelper to push branches that trigger CI.

## Tests

- `git diff --check` - passed
- `julia --project=. -e 'using Pkg; Pkg.test()'` - passed, 175 tests

## Issue

Closes #14
