### PR TITLE
Release v0.2.6

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,17 +1,15 @@
 name = "PseudoBooleanOptimization"
 uuid = "c8fa9a04-bc42-452d-8558-dc51757be744"
 authors = ["pedromxavier <pedrox@cos.ufrj.br>", "David E. Bernal Neira <dbernaln@purdue.edu>"]
-version = "0.2.5"
+version = "0.2.6"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MutableArithmetics = "d8a4904e-b15c-11e9-3269-09a3773c0cb0"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
 [compat]
 LinearAlgebra = "1"
 MutableArithmetics = "1.3"
 Random = "1"
-TOML = "1"
 julia = "1.10"

--- a/src/PseudoBooleanOptimization.jl
+++ b/src/PseudoBooleanOptimization.jl
@@ -7,12 +7,8 @@ using LinearAlgebra
 using MutableArithmetics
 const MA = MutableArithmetics
 
-# Versioning
-using TOML
 const __PROJECT__ = abspath(dirname(pathof(PBO)), "..")
-const __VERSION__ = VersionNumber(
-    getindex(TOML.parsefile(joinpath(__PROJECT__, "Project.toml")), "version"),
-)
+const __VERSION__ = pkgversion(PBO)
 
 # Interface Definition
 include("interface/variables.jl")


### PR DESCRIPTION
## Summary

- Bump package version to v0.2.6.
- Use Julia package metadata for __VERSION__ so version-only release bumps do not report a stale precompiled value.
- Remove the library TOML dependency, which was only used for manual version parsing.

## Verification

- git diff --check
- julia --project=. -e "using Pkg; Pkg.test()"
