### PR TITLE
Use dedicated TagBot deploy key

### DIFF
--- a/.github/workflows/tagbot.yml
+++ b/.github/workflows/tagbot.yml
@@ -12,4 +12,4 @@ jobs:
       - uses: JuliaRegistries/TagBot@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          ssh: ${{ secrets.DOCUMENTER_KEY }}
+          ssh: ${{ secrets.TAGBOT_SSH }}


### PR DESCRIPTION
## Summary

- Add workflow wiring for the dedicated TAGBOT_SSH secret.
- Keep docs deployment independent from TagBot SSH configuration.

Repository settings updated separately:

- Added a write-enabled deploy key titled `TagBot deploy key`.
- Added the matching private key as the `TAGBOT_SSH` repository secret.

## Verification

- `git diff --check`
- Confirmed `TAGBOT_SSH` secret exists.
- Confirmed `TagBot deploy key` exists and is write-enabled.
