### PR TITLE
Benchmark julia-actions/cache for CI runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
+      - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
         env:


### PR DESCRIPTION
Summary:
- Adds `julia-actions/cache@v3` after `julia-actions/setup-julia@v3` and before `julia-actions/julia-buildpkg@v1`.
- Leaves package code and all other workflow behavior unchanged.

Benchmark:
- CI run: https://github.com/JuliaQUBO/PseudoBooleanOptimization.jl/actions/runs/27129729624
- Attempt 1 populated the cache and passed.
- Attempt 2 restored the attempt 1 cache, saved a new cache, and passed.

| Job | Issue baseline | Attempt 1 | Attempt 2 warm | Change vs attempt 1 | Change vs issue baseline |
| --- | ---: | ---: | ---: | ---: | ---: |
| Julia 1.10 Ubuntu | 4m20s | 4m30s | 2m52s | -1m38s (-36%) | -1m28s (-34%) |
| Julia 1 Ubuntu | 6m08s | 6m18s | 3m00s | -3m18s (-52%) | -3m08s (-51%) |
| Julia 1.10 Windows | 6m18s | 6m21s | 3m56s | -2m25s (-38%) | -2m22s (-38%) |
| Julia 1 Windows | 8m55s | 8m00s | 3m40s | -4m20s (-54%) | -5m15s (-59%) |

Critical path:
- Issue baseline: 8m55s.
- Attempt 1 on this branch: 8m00s.
- Attempt 2 warm: 3m56s.
- Warm-cache critical path improved by 4m04s (-51%) versus attempt 1 and 4m59s (-56%) versus the issue baseline.

Step timing detail:

| Attempt | Job | Total | setup-julia | cache | buildpkg | runtest | coverage | codecov | post-cache |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 1 | Julia 1.10 Ubuntu | 4m30s | 5s | 0s | 5s | 3m46s | 18s | 1s | 6s |
| 1 | Julia 1 Ubuntu | 6m18s | 8s | 1s | 4s | 5m24s | 24s | 2s | 7s |
| 1 | Julia 1.10 Windows | 6m21s | 7s | 1s | 8s | 5m10s | 22s | 5s | 14s |
| 1 | Julia 1 Windows | 8m00s | 12s | 4s | 6s | 6m37s | 28s | 7s | 14s |
| 2 | Julia 1.10 Ubuntu | 2m52s | 5s | 5s | 5s | 2m02s | 17s | 2s | 11s |
| 2 | Julia 1 Ubuntu | 3m00s | 8s | 5s | 3s | 2m26s | 4s | 1s | 8s |
| 2 | Julia 1.10 Windows | 3m56s | 8s | 32s | 6s | 2m17s | 6s | 9s | 24s |
| 2 | Julia 1 Windows | 3m40s | 15s | 30s | 4s | 2m01s | 3s | 9s | 24s |

Cache evidence:
- Attempt 2 had cache hits and restored from attempt 1 for all four matrix jobs.
- Attempt 2 saved a new cache for all four matrix jobs.

Checks:
- `git diff --check`
- PR Documentation build: passed.
- PR CI attempt 1: passed.
- PR CI attempt 2 warm rerun: passed.

Closes #24
