### PR TITLE
ci: harden TagBot permissions

### DIFF
--- a/.github/workflows/tagbot.yml
+++ b/.github/workflows/tagbot.yml
@@ -4,6 +4,10 @@ on:
     types:
       - created
   workflow_dispatch:
+permissions:
+  contents: write
+  issues: write
+  pull-requests: read
 jobs:
   TagBot:
     if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'


### PR DESCRIPTION
Summary

- Add explicit TagBot workflow permissions for tag/release writes, manual-intervention issues, and PR changelog reads.
- Keep the existing SSH deploy-key configuration.

Context

- TagBot previously needed manual intervention for v0.2.6.
- This change makes the GITHUB_TOKEN permission contract explicit while preserving the configured deploy-key path.

Validation

- git diff --check

Notes

- This PR does not change package code or release metadata.
