### PR TITLE
Release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,13 @@
 
 ## Unreleased
 
+- Nothing yet.
+
+## v0.3.0 - 2026-06-24
+
+- Return planted assignments from regular XORSAT synthesis.
+- Complete planted assignments for quadratized regular XORSAT objectives.
+- Move quadratization auxiliary-assignment logic into the quadratization layer.
+- Add mod-2 linear solver coverage and expand regular XORSAT synthesis tests.
+- Harden TagBot permissions and benchmark Julia CI cache behavior.
 - Dropped Julia 1.9 support; Julia 1.10 is now the minimum supported version.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PseudoBooleanOptimization"
 uuid = "c8fa9a04-bc42-452d-8558-dc51757be744"
 authors = ["pedromxavier <pedrox@cos.ufrj.br>", "David E. Bernal Neira <dbernaln@purdue.edu>"]
-version = "0.2.6"
+version = "0.3.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"


### PR DESCRIPTION
## Summary

- Bump package version to `v0.3.0`.
- Move completed changelog entries from `Unreleased` into `v0.3.0`.

## Release Notes

- Return planted assignments from regular XORSAT synthesis.
- Complete planted assignments for quadratized regular XORSAT objectives.
- Move quadratization auxiliary-assignment logic into the quadratization layer.
- Add mod-2 linear solver coverage and expand regular XORSAT synthesis tests.
- Harden TagBot permissions and benchmark Julia CI cache behavior.
- Dropped Julia 1.9 support; Julia 1.10 is now the minimum supported version.

## Verification

- `git diff --check`
- `julia --project=. -e 'using Pkg; Pkg.test()'`
- `julia --project=docs docs/make.jl`
