### PR TITLE
Add Zenodo citation metadata for v0.3.0

### DIFF
--- a/.github/RELEASE_CHECKLIST.md
+++ b/.github/RELEASE_CHECKLIST.md
@@ -1,0 +1,39 @@
+# Release checklist
+
+Use this checklist for every tagged release. The Zenodo concept DOI
+`10.5281/zenodo.21650202` is the permanent software identifier; do not create
+another concept record for a new version.
+
+## Before tagging
+
+- [ ] Confirm at least two active maintainers have **Can manage** access to the
+      Zenodo record and all future versions.
+- [ ] Update the version in `Project.toml`, the release date and version in
+      `CITATION.cff`, and the release notes in `CHANGELOG.md`.
+- [ ] Keep the concept DOI in `CITATION.cff` and the README badge unchanged.
+- [ ] Validate the citation metadata with
+      `cffconvert --validate --infile CITATION.cff`.
+- [ ] Run the package test suite with
+      `julia --project -e 'using Pkg; Pkg.test()'`.
+
+## After publishing the GitHub release
+
+- [ ] Create a **new version** from the existing Zenodo record; do not create a
+      new upload or concept DOI.
+- [ ] Archive the official GitHub release and confirm its tag, version, MIT
+      license, repository URL, Julia package UUID
+      (`c8fa9a04-bc42-452d-8558-dc51757be744`), creators, affiliations, and
+      ORCIDs.
+- [ ] Publish the Zenodo version and record its version DOI in the GitHub
+      release notes.
+- [ ] Verify the version DOI resolves to that exact archive and the concept DOI
+      resolves to the latest archived release:
+
+      ```sh
+      curl --fail --location --output /dev/null https://doi.org/<version-doi>
+      curl --fail --location --output /dev/null https://doi.org/10.5281/zenodo.21650202
+      ```
+
+- [ ] Download the Zenodo archive, compare its checksum with the uploaded
+      release artifact, and confirm the archive contains the tagged
+      `Project.toml` version.

--- a/.github/RELEASE_CHECKLIST.md
+++ b/.github/RELEASE_CHECKLIST.md
@@ -34,6 +34,9 @@ another concept record for a new version.
       curl --fail --location --output /dev/null https://doi.org/10.5281/zenodo.21650202
       ```
 
+      If Zenodo responds slowly or returns HTTP 429, wait for its `Retry-After`
+      interval and retry once before treating the DOI as broken.
+
 - [ ] Download the Zenodo archive, compare its checksum with the uploaded
       release artifact, and confirm the archive contains the tagged
       `Project.toml` version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-- Nothing yet.
+- Add Zenodo concept and version DOI citation metadata and release archive
+  verification guidance.
 
 ## v0.3.0 - 2026-06-24
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,31 @@
+cff-version: 1.2.0
+message: "If you use PseudoBooleanOptimization.jl, please cite it using this metadata."
+title: "PseudoBooleanOptimization.jl"
+type: software
+authors:
+  - family-names: "Maciel Xavier"
+    given-names: "Pedro"
+    affiliation: "Purdue University"
+    orcid: "https://orcid.org/0000-0002-4678-4942"
+  - family-names: "Bernal Neira"
+    given-names: "David E."
+    affiliation: "Purdue University"
+    orcid: "https://orcid.org/0000-0002-8308-5016"
+abstract: >-
+  A Julia library for representing, manipulating, and quadratizing
+  pseudo-Boolean functions.
+repository-code: "https://github.com/JuliaQUBO/PseudoBooleanOptimization.jl"
+url: "https://juliaqubo.github.io/PseudoBooleanOptimization.jl/"
+license: MIT
+version: "0.3.0"
+date-released: 2026-06-24
+doi: "10.5281/zenodo.21650202"
+identifiers:
+  - type: doi
+    value: "10.5281/zenodo.21650203"
+    description: "Zenodo DOI for version 0.3.0"
+keywords:
+  - Julia
+  - pseudo-Boolean optimization
+  - quadratic unconstrained binary optimization
+  - QUBO

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 [![codecov](https://codecov.io/gh/JuliaQUBO/PseudoBooleanOptimization.jl/graph/badge.svg?token=87V5MR99ET)](https://codecov.io/gh/JuliaQUBO/PseudoBooleanOptimization.jl)
 [![CI](https://github.com/JuliaQUBO/PseudoBooleanOptimization.jl/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/JuliaQUBO/PseudoBooleanOptimization.jl/actions/workflows/ci.yml)
 [![Docs](https://img.shields.io/badge/docs-dev-blue.svg)](https://JuliaQUBO.github.io/PseudoBooleanOptimization.jl/dev)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.21650202.svg)](https://doi.org/10.5281/zenodo.21650202)
 
 </div>
 
@@ -46,3 +47,17 @@ Output:
 ```julia
 1.0x + 2.0y + 3.0z + 10.0x*y + 15.0x*z - 5.0y*z
 ```
+
+## Citation
+
+For general use, cite `PseudoBooleanOptimization.jl` with its
+[Zenodo concept DOI](https://doi.org/10.5281/zenodo.21650202). The concept DOI
+is the evergreen software identifier and resolves to the latest archived
+release. Citation metadata is available in [`CITATION.cff`](CITATION.cff).
+
+For exact-version reproducibility, cite the corresponding Zenodo version DOI.
+The archive for `v0.3.0` is
+[10.5281/zenodo.21650203](https://doi.org/10.5281/zenodo.21650203).
+
+For general discussion of the JuliaQUBO ecosystem, cite the
+[QUBO.jl ecosystem article](https://doi.org/10.1080/10556788.2026.2702926).

--- a/test/unit/citation.jl
+++ b/test/unit/citation.jl
@@ -1,0 +1,35 @@
+using TOML
+
+function test_citation_metadata()
+    @testset "Citation metadata" begin
+        repo_root = normpath(joinpath(@__DIR__, "..", ".."))
+        read_text(path) = replace(read(path, String), "\r\n" => "\n")
+
+        project   = TOML.parsefile(joinpath(repo_root, "Project.toml"))
+        citation  = read_text(joinpath(repo_root, "CITATION.cff"))
+        readme    = read_text(joinpath(repo_root, "README.md"))
+        checklist = read_text(joinpath(repo_root, ".github", "RELEASE_CHECKLIST.md"))
+
+        concept_doi = "10.5281/zenodo.21650202"
+        version_doi = "10.5281/zenodo.21650203"
+        version     = string(project["version"])
+
+        @test occursin("doi: \"$concept_doi\"", citation)
+        @test occursin("value: \"$version_doi\"", citation)
+        @test occursin("version: \"$version\"", citation)
+        @test occursin("0000-0002-4678-4942", citation)
+        @test occursin("0000-0002-8308-5016", citation)
+
+        @test occursin("badge/DOI/$concept_doi.svg", readme)
+        @test occursin("doi.org/$concept_doi", readme)
+        @test occursin("doi.org/$version_doi", readme)
+        @test occursin("10.1080/10556788.2026.2702926", readme)
+
+        @test occursin(concept_doi, checklist)
+        @test occursin("Can manage", checklist)
+        @test occursin("cffconvert --validate --infile CITATION.cff", checklist)
+        @test occursin("<version-doi>", checklist)
+    end
+
+    return nothing
+end

--- a/test/unit/unit.jl
+++ b/test/unit/unit.jl
@@ -10,6 +10,7 @@ include("quadratization.jl")
 include("synthesis.jl")
 include("print.jl")
 include("ci.jl")
+include("citation.jl")
 
 function unit_tests()
     @testset "□ Unit Tests" verbose = true begin
@@ -25,6 +26,7 @@ function unit_tests()
         test_synthesis()
         test_print()
         test_ci_configuration()
+        test_citation_metadata()
     end
 
     return nothing


### PR DESCRIPTION
## Summary

- publish the official `v0.3.0` source archive on Zenodo
- add validated CFF metadata using the concept DOI as the evergreen software identifier
- add a concept/latest DOI badge and distinguish concept from exact-version citations
- document repeatable release-time archive and citation verification
- add focused tests for the repository citation contract

## Zenodo archive

- Concept DOI: https://doi.org/10.5281/zenodo.21650202
- `v0.3.0` DOI: https://doi.org/10.5281/zenodo.21650203
- Release commit: `c9a9085407d83004ce2de93f1f68d67a7477b941`
- Archive SHA-256: `9e76014af0cbd612202960b7cfd48f241e1469fa6d2fd62f428c516560ee1f74`
- Julia package UUID: `c8fa9a04-bc42-452d-8558-dc51757be744`

The creator names, order, affiliations, and ORCIDs were approved before
publication. The Zenodo record also relates the archive to the repository,
GitHub release, and QUBO.jl ecosystem article.

## Acceptance criteria

- [x] A public software concept DOI exists.
- [ ] At least two active maintainers have **Can manage** access. One manager is
      configured for now by maintainer direction; this criterion remains
      deferred.
- [x] The current supported release has a version DOI under the concept.
- [x] `CITATION.cff` validates and README instructions distinguish concept and
      version DOIs.
- [x] Future releases have a documented archival verification checklist.

Because the second-manager criterion remains open, this PR uses `Refs #37`
instead of closing the issue. JuliaQUBO/QUBO.jl#66 remains the ecosystem-level
policy tracker.

## Validation

- `uvx --cache-dir /tmp/pbo-uv-cache --from cffconvert cffconvert --validate --infile CITATION.cff`
  (`cffconvert` 2.0.0): valid against CFF schema 1.2.0
- `julia +1.11 --project=test -e 'using Test, TOML; include("test/unit/citation.jl"); test_citation_metadata()'`:
  13/13 passed
- `julia +1.11 --project -e 'using Pkg; Pkg.test()'`: 302/302 passed
- concept and version DOI resolution: HTTP 200 to the published record
- Zenodo badge: renders `10.5281/zenodo.21650202`

## Branch Hygiene

- Base branch: `main`
- Source branch: `docs/issue-37-zenodo-citation`
- Branch point: `fa062d71e1f8b0db1e5e691fb1d1b82bca3ac1d3`
- Stacked: no
- Prerequisite PRs: none
- Open-PR file overlap at branch creation: none

Refs #37
